### PR TITLE
Tim/devel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ serial:
 clean:
 	$(MAKE) $(MFLAGS) -C Obj-serial clean
 	$(MAKE) $(MFLAGS) -C examples clean
+	$(MAKE) $(MFLAGS) -C tests clean
 
 check: serial
 	$(MAKE) $(MFLAGS) -C examples check

--- a/Obj-serial/Makefile
+++ b/Obj-serial/Makefile
@@ -22,7 +22,7 @@ default: $(EXEDIR)/ljmd-serial.x
 
 
 clean:
-	rm -f *.mod *.o $(EXEDIR)/ljmd-serial.x $(OBJ)
+	rm -f *.mod *.o $(EXEDIR)/ljmd-serial.x $(OBJ) $(EXEDIR)/*.o 
 
 # linker rule
 $(EXEDIR)/ljmd-serial.x: $(OBJ) $(MAIN).o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ OBJ=$(SRC:%.c=%.o)
 default: $(EXEDIR)/input_test.x $(EXEDIR)/kinetic_test.x $(EXEDIR)/integration_test.x $(EXEDIR)/force_test.x
 
 clean:
-	rm -f *.mod *.o $(EXEDIR)/force_test.x $(EXEDIR)/input_test.x $(EXEDIR)/kinetic_test.x $(EXEDIR)/integration_test.x 
+	rm -f *.mod *.o *.out $(EXEDIR)/force_test.x $(EXEDIR)/input_test.x $(EXEDIR)/kinetic_test.x $(EXEDIR)/integration_test.x 
 
 # linker rule
 $(EXEDIR)/force_test.x: $(OBJ) force_test.o


### PR DESCRIPTION
Improved target clean in ./Makefile to execute target clean of ./tests/Makefile and to remove *out files generated by target check in ./tests directory. By the way *.out files have been already listed into .gitignore.
All testes with success on Ulysses. 